### PR TITLE
Fix example domain in operator examples

### DIFF
--- a/GSdork.py
+++ b/GSdork.py
@@ -34,7 +34,7 @@ time.sleep(1.5)
 def G_Examples():
     print(f'''
 {Red}Operators Examples{Normal}
->> site: [exmaple.com] filetype:[pdf]
+>> site: [example.com] filetype:[pdf]
 >> inurl:[cyber] inbody [threat]
 >> passwords filetype[docx] site:[example.com]
 >> allintext:hacking


### PR DESCRIPTION
## Summary
- replace `exmaple.com` with `example.com` in `G_Examples`

## Testing
- `python GSdork.py`
- `python -m py_compile GSdork.py`


------
https://chatgpt.com/codex/tasks/task_e_68978fc0fe0c8321a9851cf3e77a595e